### PR TITLE
Decouple map points and results list

### DIFF
--- a/Web UI/CognitiveSearch.UI/Controllers/HomeController.cs
+++ b/Web UI/CognitiveSearch.UI/Controllers/HomeController.cs
@@ -79,6 +79,7 @@ namespace CognitiveSearch.UI.Controllers
             }
 
             var response = _docSearch.Search(q, searchFacets, selectFilter, currentPage, polygonString);
+            var mapresponse = _docSearch.SearchAll(q, searchFacets, selectFilter, currentPage, polygonString);
             var searchId = _docSearch.GetSearchId().ToString();
             var facetResults = new List<object>();
             var tagsResults = new List<object>();
@@ -112,6 +113,7 @@ namespace CognitiveSearch.UI.Controllers
             return new JsonResult(new DocumentResult
             {
                 Results = (response == null? null : response.Results),
+                Mapresults = (mapresponse == null? null : mapresponse.Results),
                 Facets = facetResults,
                 Tags = tagsResults,
                 Count = (response == null? 0 :  Convert.ToInt32(response.Count)),
@@ -121,6 +123,62 @@ namespace CognitiveSearch.UI.Controllers
                 IsPathBase64Encoded = _isPathBase64Encoded
             });
         }
+
+        // [HttpPost]
+        // public IActionResult GetMapDocuments(string q = "", SearchFacet[] searchFacets = null, int currentPage = 1, string polygonString = null)
+        // {
+        //     var tokens = GetContainerSasUris();
+
+        //     var selectFilter = _docSearch.Model.SelectFilter;
+
+        //     if (!string.IsNullOrEmpty(q))
+        //     {
+        //         q = q.Replace("?", "");
+        //     }
+
+        //     var response = _docSearch.SearchAll(searchFacets, selectFilter, currentPage, polygonString);
+        //     var searchId = _docSearch.GetSearchId().ToString();
+        //     var facetResults = new List<object>();
+        //     var tagsResults = new List<object>();
+
+        //     if (response != null && response.Facets != null)
+        //     {
+        //         // Return only the selected facets from the Search Model
+        //         foreach (var facetResult in response.Facets.Where(f => _docSearch.Model.Facets.Where(x => x.Name == f.Key).Any()))
+        //         {
+        //             var cleanValues = GetCleanFacetValues(facetResult);
+
+        //             facetResults.Add(new
+        //             {
+        //                 key = facetResult.Key,
+        //                 value = cleanValues
+        //             });
+        //         }
+
+        //         foreach (var tagResult in response.Facets.Where(t => _docSearch.Model.Tags.Where(x => x.Name == t.Key).Any()))
+        //         {
+        //             var cleanValues = GetCleanFacetValues(tagResult);
+
+        //             tagsResults.Add(new
+        //             {
+        //                 key = tagResult.Key,
+        //                 value = cleanValues
+        //             });
+        //         }
+        //     }
+
+        //     return new JsonResult(new DocumentResult
+        //     {
+        //         Results = (response == null? null : response.Results),
+        //         Facets = facetResults,
+        //         Tags = tagsResults,
+        //         Count = (response == null? 0 :  Convert.ToInt32(response.Count)),
+        //         SearchId = searchId,
+        //         IdField = _idField,
+        //         Token = tokens[0],
+        //         IsPathBase64Encoded = _isPathBase64Encoded
+        //     });
+        // }
 
         /// <summary>
         /// In some situations you may want to restrict the facets that are displayed in the

--- a/Web UI/CognitiveSearch.UI/Controllers/HomeController.cs
+++ b/Web UI/CognitiveSearch.UI/Controllers/HomeController.cs
@@ -124,62 +124,6 @@ namespace CognitiveSearch.UI.Controllers
             });
         }
 
-        // [HttpPost]
-        // public IActionResult GetMapDocuments(string q = "", SearchFacet[] searchFacets = null, int currentPage = 1, string polygonString = null)
-        // {
-        //     var tokens = GetContainerSasUris();
-
-        //     var selectFilter = _docSearch.Model.SelectFilter;
-
-        //     if (!string.IsNullOrEmpty(q))
-        //     {
-        //         q = q.Replace("?", "");
-        //     }
-
-        //     var response = _docSearch.SearchAll(searchFacets, selectFilter, currentPage, polygonString);
-        //     var searchId = _docSearch.GetSearchId().ToString();
-        //     var facetResults = new List<object>();
-        //     var tagsResults = new List<object>();
-
-        //     if (response != null && response.Facets != null)
-        //     {
-        //         // Return only the selected facets from the Search Model
-        //         foreach (var facetResult in response.Facets.Where(f => _docSearch.Model.Facets.Where(x => x.Name == f.Key).Any()))
-        //         {
-        //             var cleanValues = GetCleanFacetValues(facetResult);
-
-        //             facetResults.Add(new
-        //             {
-        //                 key = facetResult.Key,
-        //                 value = cleanValues
-        //             });
-        //         }
-
-        //         foreach (var tagResult in response.Facets.Where(t => _docSearch.Model.Tags.Where(x => x.Name == t.Key).Any()))
-        //         {
-        //             var cleanValues = GetCleanFacetValues(tagResult);
-
-        //             tagsResults.Add(new
-        //             {
-        //                 key = tagResult.Key,
-        //                 value = cleanValues
-        //             });
-        //         }
-        //     }
-
-        //     return new JsonResult(new DocumentResult
-        //     {
-        //         Results = (response == null? null : response.Results),
-        //         Facets = facetResults,
-        //         Tags = tagsResults,
-        //         Count = (response == null? 0 :  Convert.ToInt32(response.Count)),
-        //         SearchId = searchId,
-        //         IdField = _idField,
-        //         Token = tokens[0],
-        //         IsPathBase64Encoded = _isPathBase64Encoded
-        //     });
-        // }
-
         /// <summary>
         /// In some situations you may want to restrict the facets that are displayed in the
         /// UI. This allows you to add some heuristics to remove facets that you may consider unnecessary.

--- a/Web UI/CognitiveSearch.UI/Search/DocumentResult.cs
+++ b/Web UI/CognitiveSearch.UI/Search/DocumentResult.cs
@@ -14,6 +14,8 @@ namespace CognitiveSearch.UI
         public List<object> Facets { get; set; }
         public Document Result { get; set; }
         public IList<SearchResult<Document>> Results { get; set; }
+
+        public IList<SearchResult<Document>> Mapresults { get; set; }
         public int? Count { get; set; }
         public string Token { get; set; }
         public string DecodedPath { get; set; }

--- a/Web UI/CognitiveSearch.UI/Search/DocumentResult.cs
+++ b/Web UI/CognitiveSearch.UI/Search/DocumentResult.cs
@@ -14,7 +14,6 @@ namespace CognitiveSearch.UI
         public List<object> Facets { get; set; }
         public Document Result { get; set; }
         public IList<SearchResult<Document>> Results { get; set; }
-
         public IList<SearchResult<Document>> Mapresults { get; set; }
         public int? Count { get; set; }
         public string Token { get; set; }

--- a/Web UI/CognitiveSearch.UI/Search/DocumentSearchClient.cs
+++ b/Web UI/CognitiveSearch.UI/Search/DocumentSearchClient.cs
@@ -66,7 +66,7 @@ namespace CognitiveSearch.UI
         {
             try
             {
-                SearchParameters sp = GenerateSearchParameters(searchFacets, selectFilter, currentPage, polygonString);
+                SearchParameters sp = GenerateSearchParameters(searchFacets, selectFilter, currentPage, polygonString, false);
 
                 if (!string.IsNullOrEmpty(telemetryClient.InstrumentationKey))
                 {
@@ -83,14 +83,36 @@ namespace CognitiveSearch.UI
             return null;
         }
 
-        public SearchParameters GenerateSearchParameters(SearchFacet[] searchFacets = null, string[] selectFilter = null, int currentPage = 1, string polygonString = null)
+        public DocumentSearchResult<Document> SearchAll(string searchText, SearchFacet[] searchFacets = null, string[] selectFilter = null, int currentPage = 1, string polygonString = null)
+        {
+            try
+            {
+                SearchParameters sp = GenerateSearchParameters(searchFacets, selectFilter, currentPage, polygonString, true);
+
+                if (!string.IsNullOrEmpty(telemetryClient.InstrumentationKey))
+                {
+                    var s = GenerateSearchId(searchText, sp);
+                    _searchId = s.Result;
+                }
+
+                return _indexClient.Documents.Search(searchText, sp);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Error querying index: {0}\r\n", ex.Message.ToString());
+            }
+            return null;
+        }
+
+
+        public SearchParameters GenerateSearchParameters(SearchFacet[] searchFacets = null, string[] selectFilter = null, int currentPage = 1, string polygonString = null, bool isMap = false)
         {
             // For more information on search parameters visit: 
             // https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.search.models.searchparameters?view=azure-dotnet
             SearchParameters sp = new SearchParameters()
             {
                 SearchMode = SearchMode.All,
-                Top = 200,
+                Top = (isMap == true ? 200 : 20),
                 Skip = (currentPage - 1) * 200,
                 IncludeTotalResultCount = true,
                 QueryType = QueryType.Full,

--- a/Web UI/CognitiveSearch.UI/Search/DocumentSearchClient.cs
+++ b/Web UI/CognitiveSearch.UI/Search/DocumentSearchClient.cs
@@ -36,6 +36,10 @@ namespace CognitiveSearch.UI
 
         public static string errorMessage;
 
+        public static int mapResults = 200;
+
+        public static int docResults = 20;
+
         public DocumentSearchClient(IConfiguration configuration)
         {
             try
@@ -112,8 +116,8 @@ namespace CognitiveSearch.UI
             SearchParameters sp = new SearchParameters()
             {
                 SearchMode = SearchMode.All,
-                Top = (isMap == true ? 200 : 20),
-                Skip = (currentPage - 1) * 200,
+                Top = (isMap == true ? mapResults : docResults),
+                Skip = (currentPage - 1) * mapResults,
                 IncludeTotalResultCount = true,
                 QueryType = QueryType.Full,
                 Select = selectFilter,

--- a/Web UI/CognitiveSearch.UI/wwwroot/js/results.js
+++ b/Web UI/CognitiveSearch.UI/wwwroot/js/results.js
@@ -30,7 +30,7 @@ function GetResultsMapsHTML() {
 }
 
 //  Authenticates the map and shows some locations.
-function AuthenticateResultsMap(results) {
+function AuthenticateResultsMap(mapresults) {
     $.post('/home/getmapcredentials', {},
         function (data) {
 
@@ -43,13 +43,13 @@ function AuthenticateResultsMap(results) {
             $('#maps-viewer').html(mapsContainerHTML);
 
             // default map coordinates
-            var coordinates = [-122.32, 47.60];
+            // var coordinates = [-122.32, 47.60];
 
             // Authenticate the map using the key 
             resultsMap = new atlas.Map('myMap', {
                 autoResize: true,
                 renderWorldCopies: true,
-                center: coordinates,
+                // center: coordinates,
                 visibility: "visible",
                 zoom: 1.42,
                 minZoom: 1.42,
@@ -75,7 +75,7 @@ function AuthenticateResultsMap(results) {
                 });
             });
 
-            AddMapPoints(results);
+            AddMapPoints(mapresults);
 
             return;
         });
@@ -83,16 +83,16 @@ function AuthenticateResultsMap(results) {
 }
 
 // Adds map points and re-centers the map based on results
-function AddMapPoints(results) {
+function AddMapPoints(mapresults) {
     var coordinates;
 
     if (mapDataSource !== null) {
         // clear the data source, add new POIs and re-center the map
         mapDataSource.clear();
-        coordinates = UpdatePOIs(results, mapDataSource);
-        if (coordinates) {
-            resultsMap.setCamera({ center: coordinates });
-        }
+        coordinates = UpdatePOIs(mapresults, mapDataSource);
+        // if (coordinates) {
+        //     resultsMap.setCamera({ center: coordinates });
+        // }
     }
     else {
         //Create a data source to add it to the map 
@@ -101,7 +101,7 @@ function AddMapPoints(results) {
             clusterRadius: 45,
             clusterMaxZoom: 15
         });
-        coordinates = UpdatePOIs(results, mapDataSource);
+        coordinates = UpdatePOIs(mapresults, mapDataSource);
 
         //Wait until the map resources are ready for first set up.
         resultsMap.events.add('ready', function () {
@@ -166,7 +166,6 @@ function AddMapPoints(results) {
             });
 
             resultsMap.events.add('mouseenter', symbolLayer2, function (e) {
-                //alert(Object.keys(e.shapes[0].properties));
                 symbolLayer2.setOptions({
                     textOptions: {
                         textField: ['get', 'point_count_abbreviated'],
@@ -267,10 +266,10 @@ function UpdateMap(data) {
     if (showMap === true) {
         if (resultsMap === null) {
             // Create the map
-            AuthenticateResultsMap(data.results);
+            AuthenticateResultsMap(data.mapresults);
         }
         else {
-            AddMapPoints(results);
+            AddMapPoints(mapresults);
         }
     }
 }
@@ -278,7 +277,7 @@ function UpdateMap(data) {
 function UpdateResults(data) {
     var resultsHtml = '';
 
-    $("#doc-count").html(` Available Results: ${data.count}`);
+    $("#doc-count").html(` Available Results: ${data.count} (${data.mapresults.length} points shown on the map)`);
 
 
 

--- a/Web UI/CognitiveSearch.UI/wwwroot/js/results.js
+++ b/Web UI/CognitiveSearch.UI/wwwroot/js/results.js
@@ -42,14 +42,10 @@ function AuthenticateResultsMap(mapresults) {
             var mapsContainerHTML = GetResultsMapsHTML();
             $('#maps-viewer').html(mapsContainerHTML);
 
-            // default map coordinates
-            // var coordinates = [-122.32, 47.60];
-
             // Authenticate the map using the key 
             resultsMap = new atlas.Map('myMap', {
                 autoResize: true,
                 renderWorldCopies: true,
-                // center: coordinates,
                 visibility: "visible",
                 zoom: 1.42,
                 minZoom: 1.42,
@@ -90,9 +86,6 @@ function AddMapPoints(mapresults) {
         // clear the data source, add new POIs and re-center the map
         mapDataSource.clear();
         coordinates = UpdatePOIs(mapresults, mapDataSource);
-        // if (coordinates) {
-        //     resultsMap.setCamera({ center: coordinates });
-        // }
     }
     else {
         //Create a data source to add it to the map 
@@ -277,7 +270,7 @@ function UpdateMap(data) {
 function UpdateResults(data) {
     var resultsHtml = '';
 
-    $("#doc-count").html(` Available Results: ${data.count} (${data.mapresults.length} points shown on the map)`);
+    $("#doc-count").html(` Available Results: ${data.count}`);
 
 
 

--- a/Web UI/CognitiveSearch.UI/wwwroot/js/search.js
+++ b/Web UI/CognitiveSearch.UI/wwwroot/js/search.js
@@ -80,6 +80,7 @@ function Update(data) {
     facets = data.facets;
     tags = data.tags;
     token = data.token;
+    mapresults = data.mapresults;
 
     searchId = data.searchId;
 


### PR DESCRIPTION
## Purpose
This PR removes the coupling between the map points and the results set, by fetching the map results separately in the /getDocuments API call

Per current settings, we fetch 20 docs in the results, and 200 points on the map.

Both these can be adapted as needed.

* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->